### PR TITLE
re-enable database config, add postgres header to vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                       inline: "apt-get -y update
                                apt-get -y upgrade
                                apt-get -y install \
-                               build-essential ruby2.0 ruby2.0-dev libsqlite3-dev
+                               build-essential ruby2.0 ruby2.0-dev libsqlite3-dev libpq-dev
                                gem2.0 install bundler")
 
   # Disable automatic box update checking. If you disable this, then

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,21 +4,21 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-#default: &default
-# adapter: sqlite3
-# pool: 5
-# timeout: 5000
+default: &default
+ adapter: sqlite3
+ pool: 5
+ timeout: 5000
 
-#development:
-# <<: *default
-# database: db/development.sqlite3
+development:
+ <<: *default
+ database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
-#test:
-# <<: *default
-# database: db/test.sqlite3
+test:
+ <<: *default
+ database: db/test.sqlite3
 
 #production:
 # <<: *default


### PR DESCRIPTION
I pulled the latest code and tried running the tests - they didn't work because of missing postgres headers. I remembered what we did last night and added it to the vagrant provisioning script. Running "vagrant provision" from the featsofdaring directory will install any missing stuff.

Also I had to uncomment the config/database.yml files so the tests would run. We'll want a CI server to make sure things are in order. I made [a chore](https://www.pivotaltracker.com/story/show/75050722) for that
